### PR TITLE
Update to v1.2.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,8 +43,8 @@ jobs:
         shell: powershell
         run: |
           New-Item -Path .\build -ItemType Directory -ErrorAction Stop | Out-Null
-          7z.exe a -mx9 -spf -t7z .\build\BRB_WorkBase_Improved.7z `@".\.github\build_manifest"
+          7z.exe a -mx9 -spf -t7z .\build\BiRaitBec_WorkBase_Improved.7z `@".\.github\build_manifest"
       - name: Publish artifact
         uses: actions/upload-artifact@v3
         with:
-          path: .\build\BRB_WorkBase_Improved.7z
+          path: .\build\BiRaitBec_WorkBase_Improved.7z

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Table Of Contents
 - [BiRaitBec WorkBase Improved](#biraitbec-workbase-improved)
     - [Table Of Contents](#table-of-contents)
 - [Changelogs](#changelogs)
+    - [v1.2.1](#v121)
     - [v1.2.0](#v120)
     - [v1.1.0](#v110)
     - [v1.0.0](#v100)
@@ -14,11 +15,23 @@ Table Of Contents
 Changelogs
 ==========
 
+v1.2.1
+------
+**Summary:**
+- Loosened the naming requirements for the repack archives
+
+**Installer v1.20.7:**
+- Loosened the naming requirements for the repack archives - file extension is no longer required
+
+([TOC](#table-of-contents))
+
+
 v1.2.0
 ------
 **Summary:**
 - Fixed issue where the script would never be able to validate the patched BA2 successfully if the Installer script was run from a USB drive
 - Fixed some more invalid patched files (make sure to rebuild your patched archives!)
+- Added support for Luxor HD v1.03
 - Added Extended Validation mode to validate all the files after every step (run it via the "Installer (Extended Validation Mode).ps1" file)
 - Added Hybrid mode, allowing the repack archives to be used with alternate original BA2 archives
 - Changed to the XXH128 algorithm for (most) file validation, which should result in a significant speed increase when using NVMe or fast SSD drives
@@ -55,6 +68,8 @@ v1.2.0
 - Moved v1.0, v1.01, and v1.02 of Luxor HD texture BA2 archives to the list of OLD alternate original BA2s
 - Recalculated hashes for all files with the XXH128 algorithm
 - Cleaned up the main hashes file a bit
+
+([TOC](#table-of-contents))
 
 
 v1.1.0

--- a/Installer.ps1
+++ b/Installer.ps1
@@ -54,8 +54,8 @@ param (
 
 $scriptTimer = [System.Diagnostics.Stopwatch]::StartNew()
 
-Set-Variable "WBIVersion" -Value $(New-Object System.Version -ArgumentList @(1, 2, 0)) -Option Constant
-Set-Variable "InstallerVersion" -Value $(New-Object System.Version -ArgumentList @(1, 20, 6)) -Option Constant
+Set-Variable "WBIVersion" -Value $(New-Object System.Version -ArgumentList @(1, 2, 1)) -Option Constant
+Set-Variable "InstallerVersion" -Value $(New-Object System.Version -ArgumentList @(1, 20, 7)) -Option Constant
 
 Set-Variable "FileHashAlgorithm" -Value "XXH128" -Option Constant
 Set-Variable "RunStartTime" -Value "$((Get-Date).ToUniversalTime().ToString("yyyyMMddTHHmmssZ"))" -Option Constant
@@ -495,10 +495,9 @@ foreach ($object in $repackFiles.GetEnumerator()) {
     $existingFiles = 0
     foreach ($file in $object.Value.GetEnumerator()) {
         $fileName = $file.Substring(0, $file.LastIndexOf('.'))
-        $fileExt = $file.Substring($file.LastIndexOf('.'))
 
         # do wildcard matching
-        $potentialRepackFiles = @(Get-ChildItem -Path $dir.repack7z -File -Filter "$fileName*$fileExt")
+        $potentialRepackFiles = @(Get-ChildItem -Path $dir.repack7z -File -Filter "$fileName*")
         if ($potentialRepackFiles.Count -gt 0) { $existingFiles++ }
     }
     if ($existingFiles -gt 0) { $existingRepackFiles."$($object.Key)" = $object.Value; $repackFlags."$($object.Key)" = $true }
@@ -652,11 +651,10 @@ else {
                 $relFile = "$($dir.repack7z)\$file"
                 $altRelFile = $null
                 $fileName = $file.Substring(0, $file.LastIndexOf('.'))
-                $fileExt = $file.Substring($file.LastIndexOf('.'))
 
                 # do wildcard matching
-                # get files that match file name with anything between the end of the filename and the file extension
-                $potentialRepackFiles = @(Get-ChildItem -Path $dir.repack7z -File -Filter "$fileName*$fileExt")
+                # get files that match file name with anything after the end of the filename
+                $potentialRepackFiles = @(Get-ChildItem -Path $dir.repack7z -File -Filter "$fileName*")
                 # @($potentialRepackFiles | Where-Object
                 #   pipe potential repack files into Where-Object
                 # { $_.Length -eq

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Features
 - Will only (re)build archives it needs
 - Incremental status is printed to the screen
 - Logs are generated in the `Logs` folder
-- In 'Standard' mode, repack archives are detected in the `Repack7z` folder and automatically extracted
+- In "Standard" mode, repack archives are detected in the `Repack7z` folder and automatically extracted
 - Original BA2 archives can be used directly from the Fallout 4 Data folder
 - Verifies the repack archives, original BA2 archives, and patched BA2 archives via XXH128 hash
 - Optionally has an Extended Validation mode where files are validated after every step
@@ -305,14 +305,14 @@ This mode is designed to be a mostly automatic process which validates both inpu
 
 Notes:
 
-- Only works with vanilla original BA2 archives (if non-vanilla original BA2s are detected, mode is switched to 'Hybrid' if no texture files are present in the `PatchedFiles` folder, or 'Custom' mode if they are).
+- Only works with vanilla original BA2 archives (if non-vanilla original BA2s are detected, mode is switched to "Hybrid" if no texture files are present in the `PatchedFiles` folder, or "Custom" mode if they are).
 - If using the `Restyle` repack set, the "Author's Choice" options are automatically chosen.
 
 ([TOC](#table-of-contents))
 
 Hybrid
 ------
-This mode is similar to 'Standard' mode in that it's a mostly automatic process, but it allows alternate original BA2 archives (PhyOp/Luxor) to be used instead, sacrificing patched BA2 archive validation to do so.
+This mode is similar to "Standard" mode in that it's a mostly automatic process, but it allows alternate original BA2 archives (PhyOp/Luxor) to be used instead, sacrificing patched BA2 archive validation to do so.
 
 - Put the repack files you have downloaded into the `Repack7z` folder.
 - Put the alternate original BA2 files (PhyOp/Luxor) into the `OriginalBa2` folder.
@@ -323,7 +323,7 @@ This mode is similar to 'Standard' mode in that it's a mostly automatic process,
 
 Notes:
 
-- Only works with alternate original BA2 archives and if no texture files are present in the `PatchedFiles` folder (mode is switched to 'Custom' mode if there are texture files present in the `PatchedFiles` folder).
+- Only works with alternate original BA2 archives and if no texture files are present in the `PatchedFiles` folder (mode is switched to "Custom" mode if there are texture files present in the `PatchedFiles` folder).
 - If using the `Restyle` repack set, the "Author's Choice" options are automatically chosen.
 
 ([TOC](#table-of-contents))
@@ -362,7 +362,7 @@ Unsupported Command Line Parameters
 Most of these were added for my own convenience while testing or for debugging purposes. I take no responsibility if your computer implodes when using them.
 
 - `NoClearScreen`: Prevents the script from clearing the screen when starting up
-- `ForceOperationMode <Custom|Hybrid|Standard>`: Forces 'Custom', 'Hybrid', or 'Standard' mode of operation
+- `ForceOperationMode <Custom|Hybrid|Standard>`: Forces "Custom", "Hybrid", or "Standard" mode of operation
 - `SkipChoosingPatchedBa2Dir`: Don't display the dialog box to choose the patched BA2 folder and instead choose the default (`.\PatchedBa2`)
 - `SkipRepackValidation`: Skip the validation of the repack archives
 - `SkipRepackExtraction`: Skip the extraction of the repack archives

--- a/README.nexusbbcode
+++ b/README.nexusbbcode
@@ -43,7 +43,7 @@ This mod is also available at the [url=https://github.com/rux616/biraitbec-workb
 - Will only (re)build archives it needs
 - Incremental status is printed to the screen
 - Logs are generated in the [font=Courier New][color=#b2b2b2]Logs[/color][/font] folder
-- In 'Standard' mode, repack archives are detected in the [font=Courier New][color=#b2b2b2]Repack7z[/color][/font] folder and automatically extracted
+- In "Standard" mode, repack archives are detected in the [font=Courier New][color=#b2b2b2]Repack7z[/color][/font] folder and automatically extracted
 - Original BA2 archives can be used directly from the Fallout 4 Data folder
 - Verifies the repack archives, original BA2 archives, and patched BA2 archives via XXH128 hash
 - Optionally has an Extended Validation mode where files are validated after every step
@@ -280,11 +280,11 @@ This mode is designed to be a mostly automatic process which validates both inpu
 
 Notes:
 
-- Only works with vanilla original BA2 archives (if non-vanilla original BA2s are detected, mode is switched to 'Hybrid' if no texture files are present in the [font=Courier New][color=#b2b2b2]PatchedFiles[/color][/font] folder, or 'Custom' mode if they are).
+- Only works with vanilla original BA2 archives (if non-vanilla original BA2s are detected, mode is switched to "Hybrid" if no texture files are present in the [font=Courier New][color=#b2b2b2]PatchedFiles[/color][/font] folder, or "Custom" mode if they are).
 - If using the [font=Courier New][color=#b2b2b2]Restyle[/color][/font] repack set, the "Author's Choice" options are automatically chosen.
 
 [size=4][b][u]Hybrid:[/u][/b][/size]
-This mode is similar to 'Standard' mode in that it's a mostly automatic process, but it allows alternate original BA2 archives (PhyOp/Luxor) to be used instead, sacrificing patched BA2 archive validation to do so.
+This mode is similar to "Standard" mode in that it's a mostly automatic process, but it allows alternate original BA2 archives (PhyOp/Luxor) to be used instead, sacrificing patched BA2 archive validation to do so.
 
 - Put the repack files you have downloaded into the [font=Courier New][color=#b2b2b2]Repack7z[/color][/font] folder.
 - Put the alternate original BA2 files (PhyOp/Luxor) into the [font=Courier New][color=#b2b2b2]OriginalBa2[/color][/font] folder.
@@ -295,7 +295,7 @@ This mode is similar to 'Standard' mode in that it's a mostly automatic process,
 
 Notes:
 
-- Only works with alternate original BA2 archives and if no texture files are present in the [font=Courier New][color=#b2b2b2]PatchedFiles[/color][/font] folder (mode is switched to 'Custom' mode if there are texture files present in the [font=Courier New][color=#b2b2b2]PatchedFiles[/color][/font] folder).
+- Only works with alternate original BA2 archives and if no texture files are present in the [font=Courier New][color=#b2b2b2]PatchedFiles[/color][/font] folder (mode is switched to "Custom" mode if there are texture files present in the [font=Courier New][color=#b2b2b2]PatchedFiles[/color][/font] folder).
 - If using the [font=Courier New][color=#b2b2b2]Restyle[/color][/font] repack set, the "Author's Choice" options are automatically chosen.
 
 [size=4][b][u]Custom:[/u][/b][/size]
@@ -322,7 +322,7 @@ These (and only these) parameters are supported.
 Most of these were added for my own convenience while testing or for debugging purposes. I take no responsibility if your computer implodes when using them.
 
 - [font=Courier New][color=#b2b2b2]NoClearScreen[/color][/font]: Prevents the script from clearing the screen when starting up
-- [font=Courier New][color=#b2b2b2]ForceOperationMode <Custom|Hybrid|Standard>[/color][/font]: Forces 'Custom', 'Hybrid', or 'Standard' mode of operation
+- [font=Courier New][color=#b2b2b2]ForceOperationMode <Custom|Hybrid|Standard>[/color][/font]: Forces "Custom", "Hybrid", or "Standard" mode of operation
 - [font=Courier New][color=#b2b2b2]SkipChoosingPatchedBa2Dir[/color][/font]: Don't display the dialog box to choose the patched BA2 folder and instead choose the default ([font=Courier New][color=#b2b2b2].\PatchedBa2[/color][/font])
 - [font=Courier New][color=#b2b2b2]SkipRepackValidation[/color][/font]: Skip the validation of the repack archives
 - [font=Courier New][color=#b2b2b2]SkipRepackExtraction[/color][/font]: Skip the extraction of the repack archives


### PR DESCRIPTION
Changelog
---
**Summary:**
- Loosened the naming requirements for the repack archives

**Installer v1.20.7:**
- Loosened the naming requirements for the repack archives - file extension is no longer required