### PR TITLE
Update to v1.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Table Of Contents
 - [BiRaitBec WorkBase Improved](#biraitbec-workbase-improved)
     - [Table Of Contents](#table-of-contents)
 - [Changelogs](#changelogs)
+    - [v1.3.5](#v135)
     - [v1.3.4](#v134)
     - [v1.3.3](#v133)
     - [v1.3.2](#v132)
@@ -19,6 +20,20 @@ Table Of Contents
 
 Changelogs
 ==========
+
+v1.3.5
+------
+- [Installer] Fixed some potential failures when the user has unusual characters in the path to some folders
+- [Installer] Added support for a fallback method of finding the Fallout 4 directory
+- [Installer] Added `OriginalBa2Folder` parameter
+- [Installer] Added `PatchedBa2Folder` parameter
+- [Installer] Version bumped to `1.20.12`
+- [Functions] Fixed `Get-Fallout4DataFolder` returning an empty path for the `Steam` discovery method if the path had unusual characters in it
+- [Functions] Added `SteamFallback` discovery method to `Get-Fallout4DataFolder` function
+- [Functions] Utilize `SteamFallback` data in `Get-OriginalBa2File` function
+- [Functions] Version bumped to `1.26.2`
+
+([TOC](#table-of-contents))
 
 v1.3.4
 ------

--- a/README.md
+++ b/README.md
@@ -359,6 +359,8 @@ Unsupported Command Line Parameters
 Most of these were added for my own convenience while testing or for debugging purposes. I take no responsibility if your computer implodes when using them.
 
 - `NoClearScreen`: Prevents the script from clearing the screen when starting up
+- `OriginalBa2Folder`: Changes the OriginalBa2 folder
+- `PatchedBa2Folder`: Changes the PatchedBa2 folder
 - `ForceOperationMode <Custom|Hybrid|Standard>`: Forces "Custom", "Hybrid", or "Standard" mode of operation
 - `SkipPowerShellVersionCheck`: Skip checking that this script is being run by a supported version of PowerShell
 - `SkipProblematicDirectoryCheck`: Skip checking that this script is not being run from a problematic directory

--- a/README.nexusbbcode
+++ b/README.nexusbbcode
@@ -319,6 +319,8 @@ These (and only these) parameters are supported.
 Most of these were added for my own convenience while testing or for debugging purposes. I take no responsibility if your computer implodes when using them.
 
 - [font=Courier New][color=#b2b2b2]NoClearScreen[/color][/font]: Prevents the script from clearing the screen when starting up
+- [font=Courier New][color=#b2b2b2]OriginalBa2Folder[/color][/font]: Changes the OriginalBa2 folder
+- [font=Courier New][color=#b2b2b2]PatchedBa2Folder[/color][/font]: Changes the PatchedBa2 folder
 - [font=Courier New][color=#b2b2b2]ForceOperationMode <Custom|Hybrid|Standard>[/color][/font]: Forces "Custom", "Hybrid", or "Standard" mode of operation
 - [font=Courier New][color=#b2b2b2]SkipPowerShellVersionCheck[/color][/font]: Skip checking that this script is being run by a supported version of PowerShell
 - [font=Courier New][color=#b2b2b2]SkipProblematicDirectoryCheck[/color][/font]: Skip checking that this script is not being run from a problematic directory


### PR DESCRIPTION
Changelog
---
- [Installer] Fixed some potential failures when the user has unusual characters in the path to some folders
- [Installer] Added support for a fallback method of finding the Fallout 4 directory
- [Installer] Added `OriginalBa2Folder` parameter
- [Installer] Added `PatchedBa2Folder` parameter
- [Installer] Version bumped to `1.20.12`
- [Functions] Fixed `Get-Fallout4DataFolder` returning an empty path for the `Steam` discovery method if the path had unusual characters in it
- [Functions] Added `SteamFallback` discovery method to `Get-Fallout4DataFolder` function
- [Functions] Utilize `SteamFallback` data in `Get-OriginalBa2File` function
- [Functions] Version bumped to `1.26.2`