### PR TITLE
Update to v1.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Table Of Contents
 - [BiRaitBec WorkBase Improved](#biraitbec-workbase-improved)
     - [Table Of Contents](#table-of-contents)
 - [Changelogs](#changelogs)
+    - [v1.6.3](#v163)
     - [v1.6.2](#v162)
     - [v1.6.1](#v161)
     - [v1.6.0](#v160)
@@ -26,6 +27,13 @@ Table Of Contents
 
 Changelogs
 ==========
+
+v1.6.3
+------
+- [Installer] Ignore MSFT XVDD drives when enumerating disks
+- [Installer] Version bumped to `1.21.1`
+
+([TOC](#table-of-contents))
 
 v1.6.2
 ------

--- a/Tools/lib/Installer.ps1
+++ b/Tools/lib/Installer.ps1
@@ -64,8 +64,8 @@ param (
 
 $scriptTimer = [System.Diagnostics.Stopwatch]::StartNew()
 
-Set-Variable "WBIVersion" -Value $(New-Object System.Version -ArgumentList @(1, 6, 2)) -Option Constant
-Set-Variable "InstallerVersion" -Value $(New-Object System.Version -ArgumentList @(1, 21, 0)) -Option Constant
+Set-Variable "WBIVersion" -Value $(New-Object System.Version -ArgumentList @(1, 6, 3)) -Option Constant
+Set-Variable "InstallerVersion" -Value $(New-Object System.Version -ArgumentList @(1, 21, 1)) -Option Constant
 
 Set-Variable "FileHashAlgorithm" -Value "XXH128" -Option Constant
 Set-Variable "RunStartTime" -Value "$((Get-Date).ToUniversalTime().ToString("yyyyMMddTHHmmssZ"))" -Option Constant
@@ -139,7 +139,7 @@ $optionalOriginalArchives = @(
 # the drive information
 Get-PhysicalDisk -ErrorAction SilentlyContinue | Out-Null
 
-$driveInfo = Get-PhysicalDisk |
+$driveInfo = Get-PhysicalDisk | Where-Object { $_.FriendlyName -ne "MSFT XVDD" } |
     ForEach-Object {
         $physicalDisk = $_
         Get-Partition -DiskNumber $_.DeviceId |


### PR DESCRIPTION
Changelog
------
- [Installer] Ignore MSFT XVDD drives when enumerating disks
- [Installer] Version bumped to `1.21.1`